### PR TITLE
Don't use default features in Glenside build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Flexible Matching via Equality Saturation
 4. Annotate matched region with BYOC-style function annotations for the codegen
 
 # Utilities
+*Note: Please run `cargo build` in the `flexmatch` directory before using the utilities there.*
 - `flexmatch`: Rust interfaces that call [glenside](https://github.com/gussmith23/glenside) and apis in (my fork of) [egg](https://github.com/AD1024/egg)
 - `tests/run_eqsat`
     - Takes a **relay source file**, an output file name and config(s) (under `configs/`)

--- a/configs/linear-rewrites.json
+++ b/configs/linear-rewrites.json
@@ -5,10 +5,10 @@
         "flex-linear-rewrite"
     ],
     "compilers": {
-        "flex-linear": "ilaflex.linear"
+        "flex-linear": "ilaflex"
     },
     "composites": {
-        "flex-linear": "ilaflex"
+        "flex-linear": "ilaflex.linear"
     },
     "debug_functions": {
         "flex-linear": "lambda x, w, b: nn.bias_add(nn.dense(x, w), b)"

--- a/flexmatch/Cargo.toml
+++ b/flexmatch/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2021"
 
 [dependencies.glenside]
 git = "https://github.com/gussmith23/glenside"
-branch = "pldi-flexmatch-conv1d-dev"
+branch = "3la-pldi-push-main"
+default-features = false
+features = ["tvm"]
 
 [dependencies.egg]
 git = "https://github.com/AD1024/egg"

--- a/tests/run_eqsat.py
+++ b/tests/run_eqsat.py
@@ -18,7 +18,7 @@ def main(relay_file, output_filename, *configs):
                 print(f'Exception caught when reading {config}:\n{e}')
 
         os.chdir(os.path.join(home_dir, 'flexmatch'))
-        os.system('cargo build')
+        # os.system('cargo build')
         cmd = './target/debug/flexmatch {} {} {} {}'.format(
             relay_file,
             os.path.join(cur_dir, f'{output_filename}-rewritten.json'),


### PR DESCRIPTION
This commit turns off default features in the Glenside build to avoid an unnecessary `cplex` dependency. It also removes the call to `cargo build` from the test file and instead advises the user to build before running the test.