### PR TITLE
Make CPlex dependency in configurable

### DIFF
--- a/flexmatch/Cargo.toml
+++ b/flexmatch/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["cplex"]
+cplex = ["rplex", "glenside/cplex"]
+
 [dependencies]
 serde_json = "1.0"
 serde = "1.0.130"


### PR DESCRIPTION
Previously, the build failed if the system did not have CPlex even with `--no-default-features` because Glenside still expected CPlex. This PR properly sets Glenside's CPlex feature flag based on whether CPlex is enabled at the top level.

Please review @AD1024 