### PR TITLE
Batch-matmul-matching

### DIFF
--- a/flexmatch/Cargo.toml
+++ b/flexmatch/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.9.0"
 
 [dependencies.glenside]
 git = "https://github.com/gussmith23/glenside"
-rev = "76ab6b6525da89a28a109e038c8b5545e0f4fc1f"
+rev = "2734540de733719669eef5c8a34e849c77ac779f"
 default-features = false
 features = ["tvm"]
 

--- a/flexmatch/Cargo.toml
+++ b/flexmatch/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.9.0"
 
 [dependencies.glenside]
 git = "https://github.com/gussmith23/glenside"
-rev = "2734540de733719669eef5c8a34e849c77ac779f"
+rev = "0b6100429e328af7de9af5ff859ee41acaa9e58f"
 default-features = false
 features = ["tvm"]
 

--- a/flexmatch/src/main.rs
+++ b/flexmatch/src/main.rs
@@ -156,7 +156,7 @@ fn main() {
         let mut runner = Runner::<_, _, ()>::new(MyAnalysis::default())
             .with_egraph(egraph)
             .with_time_limit(std::time::Duration::from_secs(5))
-            .with_node_limit(100000)
+            .with_node_limit(1000000)
             .with_iter_limit(45)
             .run(&rewrites);
         info!("EqSat Complete");


### PR DESCRIPTION
Enables us to match the matmuls within batch matmuls. The matmuls are there (you can watch the egg logs to see them get matched in) but extraction doesn't seem to extract them.